### PR TITLE
Add provider and model config

### DIFF
--- a/doc/llama.txt
+++ b/doc/llama.txt
@@ -83,34 +83,43 @@ variable.
 
 Currently the default config is:
 >vim
-		let s:default_config = {
-		    \ 'endpoint':           'http://127.0.0.1:8012/infill',
-		    \ 'api_key':            '',
-		    \ 'n_prefix':           256,
-		    \ 'n_suffix':           64,
-		    \ 'n_predict':          128,
-		    \ 'stop_strings':       [],
-		    \ 't_max_prompt_ms':    500,
-		    \ 't_max_predict_ms':   500,
-		    \ 'show_info':          2,
-		    \ 'auto_fim':           v:true,
-		    \ 'max_line_suffix':    8,
-		    \ 'max_cache_keys':     250,
-		    \ 'ring_n_chunks':      16,
-		    \ 'ring_chunk_size':    64,
-		    \ 'ring_scope':         1024,
-		    \ 'ring_update_ms':     1000,
-		    \ 'keymap_trigger':     "<C-F>",
-		    \ 'keymap_accept_full': "<Tab>",
-		    \ 'keymap_accept_line': "<S-Tab>",
-		    \ 'keymap_accept_word': "<C-B>",
-		    \ 'enable_at_startup':  v:true,
-		    \ }
+                let s:default_config = {
+                    \ 'provider':          'llama_cpp',
+                    \ 'model':             '',
+                    \ 'anthropic_version': '2023-06-01',
+                    \ 'endpoint':          'http://127.0.0.1:8012/infill',
+                    \ 'api_key':           '',
+                    \ 'n_prefix':          256,
+                    \ 'n_suffix':          64,
+                    \ 'n_predict':         128,
+                    \ 'stop_strings':      [],
+                    \ 't_max_prompt_ms':   500,
+                    \ 't_max_predict_ms':  1000,
+                    \ 'show_info':         2,
+                    \ 'auto_fim':          v:true,
+                    \ 'max_line_suffix':   8,
+                    \ 'max_cache_keys':    250,
+                    \ 'ring_n_chunks':     16,
+                    \ 'ring_chunk_size':   64,
+                    \ 'ring_scope':        1024,
+                    \ 'ring_update_ms':    1000,
+                    \ 'keymap_trigger':    "<C-F>",
+                    \ 'keymap_accept_full': "<Tab>",
+                    \ 'keymap_accept_line': "<S-Tab>",
+                    \ 'keymap_accept_word': "<C-B>",
+                    \ 'enable_at_startup': v:true,
+                    \ }
 <
 
-- {endpoint}			llama.cpp server endpoint
+- {provider}                  backend provider ("llama_cpp" or "claude")
 
-- {api_key}				llama.cpp server api key (optional)
+- {model}                     model name for the selected provider
+
+- {anthropic_version}  anthropic API version (used with provider "claude")
+
+- {endpoint}                  server endpoint (auto-set for known providers)
+
+- {api_key}                   API key for the provider (required for "claude")
 
 - {n_prefix}			number of lines before the cursor location to include
 						in the local prefix


### PR DESCRIPTION
## Summary
- extend default config with provider, model, and anthropic version fields
- default provider to `llama_cpp` and set Anthropics endpoint and API key requirement when using `claude`
- document new configuration options and defaults

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b239289aec8331bf1421ebd4fc12c8